### PR TITLE
Adding AWS Glue namespace to CloudWatch namespaces

### DIFF
--- a/doc_source/aws-namespaces.md
+++ b/doc_source/aws-namespaces.md
@@ -34,6 +34,7 @@ CloudWatch namespaces are containers for metrics\. Metrics in different namespac
 |  Amazon EMR  |  `AWS/ElasticMapReduce`  | 
 |  Amazon GameLift  |  `AWS/GameLift`  | 
 |  Amazon Inspector |  `AWS/Inspector`  | 
+|  AWS Glue | `AWS/Glue`  | 
 |  AWS IoT  |  `AWS/IoT`  | 
 |  AWS Key Management Service  |  `AWS/KMS`  | 
 |  Amazon Kinesis Data Analytics  |  `AWS/KinesisAnalytics`  | 


### PR DESCRIPTION
Description of changes: Adds AWS Glue to CloudWatch namespaces documentation


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
