### PR TITLE
Add additional alarm example for missing data

### DIFF
--- a/doc_source/AlarmThatSendsEmail.md
+++ b/doc_source/AlarmThatSendsEmail.md
@@ -78,8 +78,9 @@ Column 2 shows how many of these 5 data points are missing and may need to be fi
 |  \- \- \- \- \-  |  3  |  Insufficient data  |  Retain current state  |  ALARM  |  OK  | 
 |  0 X X \- X  |  0  |  ALARM  |  ALARM  |  ALARM  |  ALARM  | 
 |  \- \- \- \- X  |  2  |  Insufficient data  |  Retain current state  |  ALARM  |  OK  | 
+|  X \- \- \- \-  |  2  |  ALARM  |  Retain current state  |  ALARM  |  OK  | 
 
-In the second row of the preceding table, the alarm stays OK even if missing data is treated as breaching, because the one existing data point is not breaching, and this is evaluated along with two missing data points which are treated as breaching\. The next time this alarm is evaluated, if the data is still missing it will go to ALARM, as that non\-breaching data point will no longer be among the 5 most recent data points retrieved\. In the fourth row, the alarm goes to ALARM state in all cases because there are enough real data points so that the setting for how to treat missing data does not need to be considered\.
+In the second row of the preceding table, the alarm stays OK even if missing data is treated as breaching, because the one existing data point is not breaching, and this is evaluated along with two missing data points which are treated as breaching\. The next time this alarm is evaluated, if the data is still missing it will go to ALARM, as that non\-breaching data point will no longer be among the 5 most recent data points retrieved\. In the fourth row, the alarm goes to ALARM state in all cases because there are enough real data points so that the setting for how to treat missing data does not need to be considered\. In the sixth row, the alarm goes to ALARM state even if missing data is treated as missing, because the oldest evaluated data point is breaching and there aren't any non\-breaching data points.
 
 In the next table, the **Period** is again set to 5 minutes, and **Datapoints to Alarm** is only 2 while **Evaluation Periods** is 3\. This is a 2 out of 3, M out of N alarm\.
 


### PR DESCRIPTION
Add additional alarm example when last data point is breaching and the rest of the data is missing. This is a critical edge case that isn't covered in the examples given, and is unintuitive since it's treated differently than other cases of breaching and missing data.

*Description of changes:*

Added an additional row to the table of examples of how missing data is evaluated. Also added a sentence explaining the reason for the alarm state in the new example.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
