### PR TITLE
Fix typo in *Configuring with pattern* example

### DIFF
--- a/doc_source/CloudWatch-Agent-procstat-process-metrics.md
+++ b/doc_source/CloudWatch-Agent-procstat-process-metrics.md
@@ -93,7 +93,7 @@ The following example `procstat` section monitors all processes with command lin
         "metrics_collected": {
             "procstat": [
                 {
-                    "exe": "config",
+                    "pattern": "config",
                     "measurement": [
                         "rlimit_memory_data_hard",
                         "rlimit_memory_data_soft",
@@ -102,7 +102,7 @@ The following example `procstat` section monitors all processes with command lin
                     ]
                 },
                 {
-                    "exe": "-c",
+                    "pattern": "-c",
                     "measurement": [
                         "rlimit_memory_data_hard",
                         "rlimit_memory_data_soft",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The _pattern_ example repeats `exe` as the name of the key when it should be `pattern` according to the documentation under the `Configuring the CloudWatch Agent for procstat` H2 header.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.