### PR TITLE
Updated spelling mistake

### DIFF
--- a/doc_source/create-iam-roles-for-cloudwatch-agent.md
+++ b/doc_source/create-iam-roles-for-cloudwatch-agent.md
@@ -9,7 +9,7 @@ The ability to write to Parameter Store is a broad and powerful permission\. You
 **Note**  
 We recently modified the following procedures by using new `CloudWatchAgentServerPolicy` and `CloudWatchAgentAdminPolicy` policies created by Amazon, instead of requiring customers to create these policies themselves\. For writing files to and downloading files from the Parameter Store, the policies created by Amazon support only files with names that start with `AmazonCloudWatch-`\. If you have a CloudWatch agent configuration file with a file name that doesn't start with `AmazonCloudWatch-`, these policies can't be used to write the file to Parameter Store or download it from Parameter Store\.
 
-## Creat IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances<a name="create-iam-roles-for-cloudwatch-agent-roles"></a>
+## Create IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances<a name="create-iam-roles-for-cloudwatch-agent-roles"></a>
 
 The first procedure creates the IAM role that you must attach to each Amazon EC2 instance that runs the CloudWatch agent\. This role provides permissions for reading information from the instance and writing it to CloudWatch\.
 


### PR DESCRIPTION
"Create IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances" was "Creat IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances"

*Description of changes:*
- Updated Spelling Mistake: "Create IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances" was "Creat IAM Roles to Use with the CloudWatch Agent on Amazon EC2 Instances"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
