### PR TITLE
Fix incorrect values in the alarm evaluation tables.

### DIFF
--- a/doc_source/AlarmThatSendsEmail.md
+++ b/doc_source/AlarmThatSendsEmail.md
@@ -79,7 +79,7 @@ Columns 3\-6 show the alarm state that would be set for each setting of how miss
 |  0 \- \- \- \-  |  2  |  `OK`  |  `OK`  |  `OK`  |  `OK`  | 
 |  \- \- \- \- \-  |  3  |  `INSUFFICIENT_DATA`  |  Retain current state  |  `ALARM`  |  `OK`  | 
 |  0 X X \- X  |  0  |  `ALARM`  |  `ALARM`  |  `ALARM`  |  `ALARM`  | 
-|  \- \- X \- \-   |  2  |  `ALARM`  |  `ALARM`  |  `ALARM`  |  `OK`  | 
+|  \- \- X \- \-   |  2  |  `INSUFFICIENT_DATA`  |  Retain current state  |  `ALARM`  |  `OK`  | 
 
 In the second row of the preceding table, the alarm stays `OK` even if missing data is treated as breaching, because the one existing data point is not breaching, and this is evaluated along with two missing data points which are treated as breaching\. The next time this alarm is evaluated, if the data is still missing it will go to `ALARM`, as that non\-breaching data point will no longer be among the 5 most recent data points retrieved\. In the fourth row, the alarm goes to `ALARM` state in all cases because there are enough real data points so that the setting for how to treat missing data doesn't need to be considered\.
 
@@ -90,9 +90,9 @@ In the next table, the **Period** is again set to 5 minutes, and **Datapoints to
 | --- | --- | --- | --- | --- | --- | 
 |  0 \- X \- X  |  0  |  `ALARM`  |  `ALARM`  |  `ALARM`  |  `ALARM`  | 
 |  0 0 X 0 X  |  0  |  `ALARM`  |  `ALARM`  |  `ALARM`  |  `ALARM`  | 
-|  0 \- X \- \-  |  1  |  `OK`  |  `OK`  |  `ALARM`  |  `OK`  | 
-|  \- \- \- \- 0  |  2  |  `OK`  |  `OK`  |  `ALARM`  |  `OK`  | 
-|  \- \- X \- \-  |  2  |  `OK`  |  Retain current state  |  `ALARM`  |  `OK`  | 
+|  0 \- X \- \-  |  1  |  `INSUFFICIENT_DATA`  |  Retain current state  |  `ALARM`  |  `OK`  | 
+|  \- \- \- \- 0  |  2  |  `INSUFFICIENT_DATA`  |  Retain current state  |  `ALARM`  |  `OK`  | 
+|  \- \- X \- \-  |  2  |  `INSUFFICIENT_DATA`  |  Retain current state  |  `ALARM`  |  `OK`  | 
 
 If data points are missing soon after you create an alarm, and the metric was being reported to CloudWatch before you created the alarm, CloudWatch retrieves the most recent data points from before the alarm was created when evaluating the alarm\.
 


### PR DESCRIPTION
The alarm state should be 'INSUFFICIENT_DATA' or 'Retain current state' when CloudWatch doesn't have enough data points to determine the alarm state.