### PR TITLE
Wrong info about aggregating data across Regions using CloudWatch

### DIFF
--- a/doc_source/GetSingleMetricAllDimensions.md
+++ b/doc_source/GetSingleMetricAllDimensions.md
@@ -1,6 +1,6 @@
 # Aggregating Statistics Across Resources<a name="GetSingleMetricAllDimensions"></a>
 
-You can aggregate the metrics for AWS resources across multiple resources\. Amazon CloudWatch can't aggregate data across Regions\. Metrics are completely separate between Regions\.
+You can aggregate the metrics for AWS resources across multiple resources\. Metrics are completely separate between Regions but you can use CloudWatch metric math to aggregate and transform metrics from multiple accounts and Regions\.
 
 For example, you can aggregate statistics for your EC2 instances that have detailed monitoring enabled\. Instances that use basic monitoring aren't included\. Therefore, you must enable detailed monitoring \(at an additional charge\), which provides data in 1\-minute periods\. For more information, see [Enable or Disable Detailed Monitoring for Your Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-cloudwatch-new.html) in the *Amazon EC2 User Guide for Linux Instances*\.
 


### PR DESCRIPTION

*Issue #, if available:* Rectified wrong information about CloudWatch data aggregation of metrics across Regions

*Description of changes:*

Since November 2019, you can now use CloudWatch metric math to aggregate and transform metrics from multiple accounts and Regions. Hence, this statement is incorrect: Amazon CloudWatch can't aggregate data across Regions.

Reference: 

https://aws.amazon.com/about-aws/whats-new/2019/11/amazon-cloudwatch-launches-cross-account-cross-region-dashboards/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
