### PR TITLE
Fix SEARCH examples

### DIFF
--- a/doc_source/search-expression-syntax.md
+++ b/doc_source/search-expression-syntax.md
@@ -171,11 +171,11 @@ SEARCH(' {AWS/Lambda,FunctionName} MetricName="Errors" OR (MetricName="Invocatio
 
 You can use a search expression within a math expressions in a graph\. 
 
-For example, **SUM\(SEARCH\(' \{AWS/Lambda, FunctionName\}, MetricName="Errors" ', 'Sum', 300\)\)** returns the sum of the `Errors` metric of all your Lambda functions\.
+For example, **SUM\(SEARCH\(' \{AWS/Lambda, FunctionName\} MetricName="Errors" ', 'Sum', 300\)\)** returns the sum of the `Errors` metric of all your Lambda functions\.
 
 Using separate lines for your search expression and math expression might yield more useful results\. For example, suppose that you use the following two expressions in a graph\. The first line displays separate `Errors` lines for each of your Lambda functions\. The ID of this expression is `e1`\. The second line adds another line showing the sum of the errors from all of the functions\.
 
 ```
-SEARCH(' {AWS/Lambda, FunctionName}, MetricName="Errors" ', 'Sum', 300)
+SEARCH(' {AWS/Lambda, FunctionName} MetricName="Errors" ', 'Sum', 300)
 SUM(e1)
 ```


### PR DESCRIPTION
Hello, dear colleagues! :)

*Description of changes:*

The search syntax does not actually allow a `,` after the `{...}`, and that's not used anywhere else in the page.

Btw, it would be nice if a bit of a cleanup was done on these docs, they are _really_ hard to follow, and I've been doing nothing but dashboards the past two weeks.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
