### PR TITLE
Update container insights documentation to use latest appmesh version v1.0.0

### DIFF
--- a/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh-envoy.md
+++ b/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh-envoy.md
@@ -6,44 +6,7 @@ You can set up Container Insights FluentD to send App Mesh Envoy access logs to 
 
 1. Set up FluentD in the cluster\. For more information, see [Set Up FluentD as a DaemonSet to Send Logs to CloudWatch Logs](Container-Insights-setup-logs.md)\.
 
-1. Configure Envoy access logs for your virtual nodes\. Be sure to configure the log path to be **/dev/stdout** in each virtual node\. There are three methods for enabling and configuring the logs:
+1. [Configure Envoy access logs](https://docs.aws.amazon.com/app-mesh/latest/userguide/observability.html#envoy-logs) for your virtual nodes\. Be sure to configure the log path to be **/dev/stdout** in each virtual node\.
 
-   1. Use the App Mesh console\. For instructions on how to use the App Mesh console to configure the logs, see [Access logs](https://docs.aws.amazon.com/app-mesh/latest/userguide/envoy.html#envoy-logs)\.
-
-   1. To use the App Mesh CLI to enable or update the Envoy access logs, use the `update-virtual-node` command\. For more information, see [update\-virtual\-node](https://docs.aws.amazon.com/cli/latest/reference/appmesh/update-virtual-node.html)\.
-
-   1. If you created Virtual Nodes using App Mesh Kubernetes Controller, use this option. To use the YAML file, add the bold `logging` section of the YAML file shown below when you create or update your virtual node. The following sample YAML is for [howto-k8s-http-headers walkthrough](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http-headers) used earlier\.
-
-      ```
-      ---
-      apiVersion: appmesh.k8s.aws/v1beta2
-      kind: VirtualNode
-      metadata:
-        name: blue
-        namespace: howto-k8s-http-headers
-      spec:
-        podSelector:
-          matchLabels:
-            app: color
-            version: blue
-        listeners:
-          - portMapping:
-              port: 8080
-              protocol: http
-            healthCheck:
-              protocol: http
-              path: '/ping'
-              healthyThreshold: 2
-              unhealthyThreshold: 2
-              timeoutMillis: 2000
-              intervalMillis: 5000
-        serviceDiscovery:
-          dns:
-            hostname: color-blue.howto-k8s-http-headers.svc.cluster.local
-        logging:
-          accessLog:
-            file:
-              path: "/dev/stdout"
-      ```
 
 When you have finished, the envoy access logs are sent to the `/aws/containerinsights/Cluster_Name/application` log group\.

--- a/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh-envoy.md
+++ b/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh-envoy.md
@@ -12,24 +12,34 @@ You can set up Container Insights FluentD to send App Mesh Envoy access logs to 
 
    1. To use the App Mesh CLI to enable or update the Envoy access logs, use the `update-virtual-node` command\. For more information, see [update\-virtual\-node](https://docs.aws.amazon.com/cli/latest/reference/appmesh/update-virtual-node.html)\.
 
-   1. To use the YAML file, add the bold `logging` section of the YAML file shown below when you create or update your virtual node\.
+   1. If you created Virtual Nodes using App Mesh Kubernetes Controller, use this option. To use the YAML file, add the bold `logging` section of the YAML file shown below when you create or update your virtual node. The following sample YAML is for [howto-k8s-http-headers walkthrough](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http-headers) used earlier\.
 
       ```
       ---
-      apiVersion: appmesh.k8s.aws/v1beta1
+      apiVersion: appmesh.k8s.aws/v1beta2
       kind: VirtualNode
       metadata:
-        name: metal-v2
-        namespace: {{namespace}}
+        name: blue
+        namespace: howto-k8s-http-headers
       spec:
-        meshName: {{appmeshname}}
+        podSelector:
+          matchLabels:
+            app: color
+            version: blue
         listeners:
           - portMapping:
-              port: 9080
+              port: 8080
               protocol: http
+            healthCheck:
+              protocol: http
+              path: '/ping'
+              healthyThreshold: 2
+              unhealthyThreshold: 2
+              timeoutMillis: 2000
+              intervalMillis: 5000
         serviceDiscovery:
           dns:
-            hostName: metal-v2.{{namespace}}.svc.cluster.local
+            hostname: color-blue.howto-k8s-http-headers.svc.cluster.local
         logging:
           accessLog:
             file:

--- a/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh.md
+++ b/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh.md
@@ -42,7 +42,7 @@ To install App Mesh Kubernetes Controller, follow these instructions on [appmesh
 
 1. Open the CloudWatch console at [https://console\.aws\.amazon\.com/cloudwatch/](https://console.aws.amazon.com/cloudwatch/)\.
 
-1. In the AWS Region where your cluster is running, choose **Metrics**\. The App Mesh meetrics are in the **ContainerInsights/Prometheus** namespace\.
+1. In the AWS Region where your cluster is running, choose **Metrics**\. The App Mesh metrics are in the **ContainerInsights/Prometheus** namespace\.
 
 1. To see the CloudWatch Logs events, choose **Log Groups** in the navigation pane\. The events are in the log group **/aws/containerinsights/*your\_cluster\_name*/prometheus**, in the log stream **kubernetes\-pod\-appmesh\-envoyappmesh**\.
 

--- a/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh.md
+++ b/doc_source/ContainerInsights-Prometheus-Sample-Workloads-appmesh.md
@@ -10,103 +10,35 @@ You must add the **AWSAppMeshFullAccess** policy to the IAM role for your Amazon
 
 ## Install App Mesh<a name="ContainerInsights-Prometheus-Sample-Workloads-appmesh-install"></a>
 
-Follow these steps to install App Mesh\.
+To install App Mesh Kubernetes Controller, follow these instructions on [appmesh-controller](https://github.com/aws/eks-charts/tree/master/stable/appmesh-controller#app-mesh-controller) Helm chart\.
 
-**To install App Mesh for testing with CloudWatch Container Insights Prometheus support**
 
-1. Enter the following command to add the Helm repo\. This repo works on both Amazon EKS and Kubernetes clusters\.
+## Install a Sample Application<a name="ContainerInsights-Prometheus-Sample-Workloads-appmesh-app-install"></a>
 
-   ```
-   helm repo add eks https://aws.github.io/eks-charts
-   ```
+[aws-app-mesh-examples](https://github.com/aws/aws-app-mesh-examples) contains several Kubernetes App Mesh walkthroughs. For this tutorial, install a sample Color application that shows how http routes can use headers for matching incoming requests\.
 
-1. Enter the following command to apply the App Mesh custom resource definition:
+1. Install the application using the instructions [here](https://github.com/aws/aws-app-mesh-examples/tree/master/walkthroughs/howto-k8s-http-headers)\.
 
-   ```
-   kubectl apply -f https://raw.githubusercontent.com/aws/eks-charts/master/stable/appmesh-controller/crds/crds.yaml
-   ```
+1. Launch a curler pod to generate traffic:
 
-1. Set the environment variables for the App Mesh workload\. The following lines are an example, you can choose your own environment variables:
+    ```
+    kubectl -n default run -it curler --image=tutum/curl /bin/bash
+    ```
+1. Curl different endpoints by changing HTTP headers (run the curl command multiple times)\.
 
-   ```
-   APPMESH_NAME=appmesh-sample
-   APPMESH_SYSTEM_NAMESPACE=appmesh-system-sample
-   APPMESH_SAMPLE_TRAFFIC_NAMESPACE=appmesh-sample-traffic-test
-   ```
+    ```
+    curl -H "color_header: blue" front.howto-k8s-http-headers.svc.cluster.local:8080/; echo;
+    ```
 
-1. Install the App Mesh custom resource definition controller by entering the following commands:
+    ```
+    curl -H "color_header: red" front.howto-k8s-http-headers.svc.cluster.local:8080/; echo;
+    ```
 
-   ```
-   kubectl create namespace $APPMESH_SYSTEM_NAMESPACE
-   helm upgrade -i appmesh-controller eks/appmesh-controller \
-   --namespace $APPMESH_SYSTEM_NAMESPACE
-   ```
+    ```
+    curl -H "color_header: yellow" front.howto-k8s-http-headers.svc.cluster.local:8080/; echo;
+    ```
 
-1. Install the App Mesh injector by entering the following command:
-
-   ```
-   helm upgrade -i appmesh-inject eks/appmesh-inject \
-   --namespace $APPMESH_SYSTEM_NAMESPACE \
-   --set mesh.create=true \
-   --set mesh.name=$APPMESH_NAME \
-   --set stats.tagsEnabled=true
-   ```
-
-1. \(Optional\) To confirm that the sample service mesh has been created, 0pen the App Mesh console at [https://console\.aws\.amazon\.com/app\-mesh/](https://console.aws.amazon.com/app-mesh/)\. Set the console to the AWS Region where your cluster is running, and choose **Meshes**\. You should see a new mesh named appmesh\-sample\.
-
-1. Create App Mesh testing traffic by entering the following command:
-
-   ```
-   curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/appmesh/appmesh_traffic_sample.yaml | 
-   sed "s/{{appmeshname}}/$APPMESH_NAME/g" | 
-   sed "s/{{namespace}}/$APPMESH_SAMPLE_TRAFFIC_NAMESPACE/g" | 
-   kubectl apply -f -
-   ```
-
-1. \(Optional\) Install a second App Mesh workload service to generate 404 and 503 response codes by entering the following command:
-
-   ```
-   APPMESH_SAMPLE_ERROR_TRAFFIC_NAMESPACE=appmesh-sample-errortraffic-test
-   ```
-
-   ```
-   curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/appmesh/appmesh_traffic_sample_4xx5xx.yaml | 
-   sed "s/{{appmeshname}}/$APPMESH_NAME/g" | 
-   sed "s/{{namespace}}/$APPMESH_SAMPLE_ERROR_TRAFFIC_NAMESPACE/g" | 
-   kubectl apply -f -
-   ```
-
-1. Find the name of the traffic generator by entering the following command:
-
-   ```
-   kubectl get pod -n $APPMESH_SAMPLE_TRAFFIC_NAMESPACE 
-   ```
-
-   The traffic generator is in the NAME column and starts with `traffic-generator`
-
-1. Find the name of the virtual service by entering the following command:
-
-   ```
-   kubectl get virtualservice.appmesh.k8s.aws -n $APPMESH_SAMPLE_TRAFFIC_NAMESPACE
-   ```
-
-1. Remote exec into the traffic generator pod by entering the following comman\. Substitute *traffic\-generator\-name* with the name of the traffic generator that you found in step 9\.
-
-   ```
-   kubectl exec -ti traffic-generator-name bash -n $APPMESH_SAMPLE_TRAFFIC_NAMESPACE
-   ```
-
-1. Run the curl command multiple times, using the name of the virtual service that you found in step 10\.
-
-   ```
-   curl virtual_servie_name:9080;echo
-   ```
-
-1. Exit the pod by entering the following command:
-
-   ```
-   Exit
-   ```
+## Check CloudWatch Metrics and Logs<a name="ContainerInsights-Prometheus-Sample-Workloads-appmesh-cw-check"></a>
 
 1. Open the CloudWatch console at [https://console\.aws\.amazon\.com/cloudwatch/](https://console.aws.amazon.com/cloudwatch/)\.
 
@@ -114,67 +46,20 @@ Follow these steps to install App Mesh\.
 
 1. To see the CloudWatch Logs events, choose **Log Groups** in the navigation pane\. The events are in the log group **/aws/containerinsights/*your\_cluster\_name*/prometheus**, in the log stream **kubernetes\-pod\-appmesh\-envoyappmesh**\.
 
-## Troubleshooting App Mesh<a name="ContainerInsights-Prometheus-Sample-Workloads-appmesh-troubleshooting"></a>
-
-The following can help you troubleshoot your App Mesh testing setup\.
-
-**Pod Initialized in Pending Status**
-
-This example setup creates 20 pods\. You can check whether any pods are still pending by entering the following commands:
-
-```
-kubectl get pod -n $APPMESH_SYSTEM_NAMESPACE
-kubectl get pod -n $APPMESH_SAMPLE_TRAFFIC_NAMESPACE
-kubectl get pod -n $APPMESH_SAMPLE_ERROR_TRAFFIC_NAMESPACE
-```
-
-If any pods are pending, your cluster might not have enough CPU or memory capacity to provision the required pods\. To solve this, provision a new EC2 instance to your cluster\.
-
-**Error Running Load Generator**
-
-You might see the following message when you run the load generator:
-
-```
-curl: (7) Failed to connect to jazz.appmesh-sample-traffic-test.svc.cluster.local port 9080: Connection refused
-```
-
-This could that the App Mesh IAM policy is not set up on the node group\. To solve this, add the **AWSAppMeshFullAccess** policy to the IAM role for your Amazon EKS or Kubernetes node group\. On Amazon EKS, this node group name looks similar to **eksctl\-integ\-test\-eks\-prometheus\-NodeInstanceRole\-ABCDEFHIJKL**\. On Kubernetes, it might look similar to **nodes\.integ\-test\-kops\-prometheus\.k8s\.local**\.
-
-Once you have done this, confirm that the sample service mesh has been created\. 0pen the App Mesh console at [https://console\.aws\.amazon\.com/app\-mesh/](https://console.aws.amazon.com/app-mesh/)\. Set the console to the AWS Region where your cluster is running, and choose **Meshes**\. You should see a new mesh named appmesh\-sample\.
-
 ## Deleting The App Mesh Test Environment<a name="ContainerInsights-Prometheus-Sample-Workloads-appmesh-cleanup"></a>
 
-When you have finished using App Mesh and the traffic generator for testing, use the following commands to delete the unnecessary resources\.
+When you have finished using App Mesh and the sample application, use the following commands to delete the unnecessary resources\.
 
-Delete the sample traffic by entering the following command:
-
-```
-curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/appmesh/appmesh_traffic_sample_4xx5xx.yaml | 
-sed "s/{{appmeshname}}/$APPMESH_NAME/g" | 
-sed "s/{{namespace}}/$APPMESH_SAMPLE_ERROR_TRAFFIC_NAMESPACE/g" | 
-kubectl delete -f -curl https://raw.githubusercontent.com/aws-samples/amazon-cloudwatch-container-insights/prometheus-beta/k8s-deployment-manifest-templates/deployment-mode/service/cwagent-prometheus/sample_traffic/appmesh/appmesh_traffic_sample.yaml | 
-sed "s/{{appmeshname}}/$APPMESH_NAME/g" | 
-sed "s/{{namespace}}/$APPMESH_SAMPLE_TRAFFIC_NAMESPACE/g" | 
-kubectl delete -f -
-```
-
-Delete the App Mesh controller and injector by entering the following command:
+Delete the sample application by entering the following command:
 
 ```
-kubectl delete namespace appmesh-system-sample
+cd aws-app-mesh-examples/walkthroughs/howto-k8s-http-headers/
+kubectl delete -f _output/manifest.yaml
 ```
 
-Delete the App Mesh controller cluster\-level objects:
+Delete the App Mesh controller by entering the following command:
 
 ```
-kubectl delete clusterrole appmesh-controller
-kubectl delete clusterrolebinding appmesh-controller
+helm delete appmesh-controller -n appmesh-system
 ```
 
-Delete the App Mesh injector cluster level objects:
-
-```
-kubectl delete clusterrole appmesh-inject
-kubectl delete clusterrolebinding appmesh-inject
-kubectl delete MutatingWebhookConfiguration appmesh-inject
-```


### PR DESCRIPTION
*Description of changes:*
AWS App Mesh did a major version upgrade and the existing installation instructions are out of date. Updated the instructions to include the up to date App Mesh Kubernetes controller installation instruction, link to a new sample application and Virtual Node YAML for Envoy logging. 

Also, the new instructions simply refer to the existing links. EKS/AppMesh teams will keep those links up to date for future releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
