### PR TITLE
Remove the excess space character in the HAProxy Helm Installation Co…

### DIFF
--- a/doc_source/ContainerInsights-Prometheus-Sample-Workloads-haproxy.md
+++ b/doc_source/ContainerInsights-Prometheus-Sample-Workloads-haproxy.md
@@ -21,9 +21,9 @@ HAProxy is an open\-source proxy application\. For more information, see [HAProx
    ```
    helm install haproxy incubator/haproxy-ingress \
    --namespace haproxy-ingress-sample \
-   --set controller.stats.enabled=true \ 
-   --set controller.metrics.enabled=true \ 
-   --set-string controller.metrics.service.annotations."prometheus\.io/port"="9101" \ 
+   --set controller.stats.enabled=true \
+   --set controller.metrics.enabled=true \
+   --set-string controller.metrics.service.annotations."prometheus\.io/port"="9101" \
    --set-string controller.metrics.service.annotations."prometheus\.io/scrape"="true"
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Three excess spaces behind the `\` will cause the copy-paste-run the command failure, e.g:

```
% helm install haproxy incubator/haproxy-ingress \
--namespace haproxy-ingress-sample \
--set controller.stats.enabled=true \
--set controller.metrics.enabled=true \
--set-string controller.metrics.service.annotations."prometheus\.io/port"="9101" \
--set-string controller.metrics.service.annotations."prometheus\.io/scrape"="true"
Error: must either provide a name or specify --generate-name
zsh: command not found: --set
zsh: command not found: --set-string
zsh: command not found: --set-string
``` 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
