### PR TITLE
remove kube-proxy from log group "dataplane"

### DIFF
--- a/doc_source/Container-Insights-setup-logs.md
+++ b/doc_source/Container-Insights-setup-logs.md
@@ -7,7 +7,7 @@ To set up FluentD to collect logs from your containers, you can follow the steps
 | --- | --- | 
 |  `/aws/containerinsights/Cluster_Name/application`  |  All log files in `/var/log/containers`  | 
 |  `/aws/containerinsights/Cluster_Name/host`  |  Logs from `/var/log/dmesg`, `/var/log/secure`, and `/var/log/messages`  | 
-|  `/aws/containerinsights/Cluster_Name/dataplane`  |  The logs in `/var/log/journal` for `kubelet.service`, `kubeproxy.service`, and `docker.service`\.  | 
+|  `/aws/containerinsights/Cluster_Name/dataplane`  |  The logs in `/var/log/journal` for `kubelet.service`, and `docker.service`\.  | 
 
 ## Step 1: Create a Namespace for CloudWatch<a name="create-namespace-logs"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

About EKS, the kube-proxy is ran as a daemonSet pod.
(At least on Amazon EKS-Optimized Amazon Linux 2 AMIs.)

Therefore, kubeproxy.service is not used.
The description contained in the log group /AWS/ContainerInsights/cluster_name/dataPlan is misleading.

*Description of changes:*

I removed Kubeproxy.Service from the Loggroup "/AWS/ContainerInsights/cluster_name/dataPlane".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
