### PR TITLE
fix typo in word "utilization"

### DIFF
--- a/doc_source/Container-Insights-metrics-ECS.md
+++ b/doc_source/Container-Insights-metrics-ECS.md
@@ -42,7 +42,7 @@ The following metrics are available when you complete the steps in [Deploying th
 |  `instance_filesystem_utilization` |  ClusterName EC2InstanceId, ContainerInstanceId,ClusterName  |  The total percentage of file system capacity being used on a single EC2 instance in the cluster\.   | 
 |  `instance_memory_limit` |  ClusterName  |  The maximum amount of memory, in bytes, that can be assigned to a single EC2 Instance in this cluster\.   | 
 |  `instance_memory_reserved_capacity` |  ClusterName EC2InstanceId, ContainerInstanceId,ClusterName  |  The percentage of Memory currently being reserved on a single EC2 Instance in the cluster\.  | 
-|  `instance_memory_utliization` |  ClusterName EC2InstanceId, ContainerInstanceId,ClusterName  |  The total percentage of memory being used on a single EC2 Instance in the cluster\.  | 
+|  `instance_memory_utilization` |  ClusterName EC2InstanceId, ContainerInstanceId,ClusterName  |  The total percentage of memory being used on a single EC2 Instance in the cluster\.  | 
 |  `instance_memory_working_set` |  ClusterName  |  The amount of memory, in bytes, being used on a single EC2 Instance in the cluster\.  | 
 |  `instance_network_total_bytes` |  ClusterName  |  The total number of bytes per second transmitted and received over the network on a single EC2 Instance in the cluster\.  | 
 |  `instance_number_of_running_tasks` |  ClusterName  |  The number of running tasks on a single EC2 Instance in the cluster\.  | 


### PR DESCRIPTION
Fix a typo in the word "utilization" in the file "Container-Insights-metrics-ECS.md"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
