### PR TITLE
fix hyperlink referencing SampleApp.yml

### DIFF
--- a/doc_source/appinsights-tutorial-dotnet-sql.md
+++ b/doc_source/appinsights-tutorial-dotnet-sql.md
@@ -45,7 +45,7 @@ The template deployment takes approximately 10 minutes to complete\.
 
 1. Under **Specify template**, select **Amazon S3 URL** and enter the following S3 URL path: `https://application-insights-demo-resources.s3.amazonaws.com/SampleApp.yml`\. Choose **Next**\.
 **Note**  
-This CloudFormation template can also be found in the aws\-samples GitHub repo at the following location: [https://github\.com/aws\-samples/application\-insights\-sample\-application/blob/master/SampleApp\.yml](https://github.com/aws-samples/application-insights-sample-application/edit/blob/SampleApp.yml)\.
+This CloudFormation template can also be found in the aws\-samples GitHub repo at the following location: [https://github\.com/aws\-samples/application\-insights\-sample\-application/blob/master/SampleApp\.yml](https://github.com/aws-samples/application-insights-sample-application/blob/master/SampleApp.yml)\.
 
 1. On the **Specify stack details** page, enter a name for the stack, such as `ApplicationInsightsTest`\.
 


### PR DESCRIPTION
*Description of changes:*

The underlying link to SampleApp.yml was wrong (the description text is correct)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
