### PR TITLE
Clarify conditions for incrementing cluster_failed_node_count

### DIFF
--- a/doc_source/Container-Insights-metrics-EKS.md
+++ b/doc_source/Container-Insights-metrics-EKS.md
@@ -9,7 +9,7 @@ When you use Container Insights to collect the following metrics, the metrics ar
 
 | Metric Name | Dimensions | Description | 
 | --- | --- | --- | 
-|  `cluster_failed_node_count` |  ClusterName  |  The number of failed worker nodes in the cluster\.  | 
+|  `cluster_failed_node_count` |  ClusterName  |  The number of failed worker nodes in the cluster\. A node is considered failed if it is suffering from any [node conditions](https://github.com/kubernetes/node-problem-detector#remedy-systems)\.  | 
 |  `cluster_node_count` |  ClusterName  |  The total number of worker nodes in the cluster\.  | 
 |  `namespace_number_of_running_pods` |  Namespace ClusterName ClusterName  |  The number of pods running per namespace in the resource that is specified by the dimensions that you're using\.  | 
 |  `node_cpu_limit` |  ClusterName  |  The maximum number of CPU units that can be assigned to a single node in this cluster\.  | 

--- a/doc_source/Container-Insights-metrics-EKS.md
+++ b/doc_source/Container-Insights-metrics-EKS.md
@@ -9,7 +9,7 @@ When you use Container Insights to collect the following metrics, the metrics ar
 
 | Metric Name | Dimensions | Description | 
 | --- | --- | --- | 
-|  `cluster_failed_node_count` |  ClusterName  |  The number of failed worker nodes in the cluster\. A node is considered failed if it is suffering from any [node conditions](https://github.com/kubernetes/node-problem-detector#remedy-systems)\.  | 
+|  `cluster_failed_node_count` |  ClusterName  |  The number of failed worker nodes in the cluster\. A node is considered failed if it is suffering from any [node conditions](https://kubernetes.io/docs/concepts/architecture/nodes/#condition)\.  | 
 |  `cluster_node_count` |  ClusterName  |  The total number of worker nodes in the cluster\.  | 
 |  `namespace_number_of_running_pods` |  Namespace ClusterName ClusterName  |  The number of pods running per namespace in the resource that is specified by the dimensions that you're using\.  | 
 |  `node_cpu_limit` |  ClusterName  |  The maximum number of CPU units that can be assigned to a single node in this cluster\.  | 


### PR DESCRIPTION
*Issue #, if available:*
#70 

*Description of changes:*
Fixes description of the `cluster_failed_node_count` metric. This description in its current form is not particularly useful, because it doesn't allow you to diagnose why this alarm is going off. Based on discussions with an AWS Solutions Architect, this is the condition for this metric.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
