### PR TITLE
Fixed the curly brackets.

### DIFF
--- a/doc_source/graph-dynamic-labels.md
+++ b/doc_source/graph-dynamic-labels.md
@@ -14,11 +14,31 @@ Within a dynamic label, the dynamic values can include the following:
 | Variable | Description | 
 | --- | --- | 
 |  $\{AVG\} |  The average of the values in the time range currently shown in the graph\.  | 
+|  $\{DATAPOINT_COUNT\} | The number of data points in the time range that is currently shown in the graph\.  | 
+|  $\{FIRST\} |  The oldest of the metric values in the time range that is currently shown in the graph\.  |
+|  $\{FIRST_LAST_RANGE\} |  The difference between the metric values of the oldest and newest data points that are currently shown in the graph\.  | 
+|  $\{FIRST_LAST_TIME_RANGE\} |  The absolute time range between the oldest and newest data points that are currently shown in the graph\.  | 
+|  $\{FIRST_TIME\} |  The timestamp of the oldest data point in the time range that is currently shown in the graph\.  | 
+|  $\{FIRST_TIME_RELATIVE\} |  The absolute time difference between now and the timestamp of the oldest data point in the time range that is currently shown in the graph\.  | 
+|  $\{LABEL\} |  Represents the default label for a metric\.  | 
 |  $\{LAST\} |  The most recent of the values in the time range currently shown in the graph\.  | 
-|  $\{LABEL\} |  Represents the default label for a metric  | 
+|  $\{LAST_TIME\} |  The timestamp of the newest data point in the time range that is currently shown in the graph\.  | 
+|  $\{LAST_TIME_RELATIVE\} |  The absolute time difference between now and the timestamp of the newest data point in the time range that is currently shown in the graph\.  | 
 |  $\{MAX\} |  The maximum of the values in the time range currently shown in the graph\.  | 
 |  $\{MIN\} |  The minimum of the values in the time range currently shown in the graph\.  | 
+|  $\{MIN_MAX_RANGE\} |  The difference in metric values between the data points with the highest and lowest metric values, of those data points that are currently shown in the graph\.  |
+|  $\{MIN_MAX_TIME_RANGE\} |  The absolute time range between the data points with the highest and lowest metric values, of those data points that are currently shown in the graph\.  |
+|  $\{MIN_TIME\} |  The timestamp of the data point that has the lowest metric value, of the data points that are currently shown in the graph\.  |
+|  $\{MIN_TIME_RELATIVE\} |  The absolute time difference between now and the timestamp of the data point with the lowest value, of those data points that are currently shown in the graph\.  |
+|  $\{PROP('AccountId')\} |  The AWS account ID of the metric\.  |
+|  $\{PROP('Dim.*dimension_name*')\}   |  The value of the specified dimension\.  |
+|  $\{PROP('MetricName')\} |  The name of the metric\.  |
+|  $\{PROP('Namespace')\} |  The namespace of the metric\.  |
+|  $\{PROP('Period')\} |  The period of the metric, in seconds\.  |
+|  $\{PROP('Region')\} |  The AWS Region where the metric is published\.  |
+|  $\{PROP('Stat')\} |  The metric statistic that is being graphed\.  |
 |  $\{SUM\} |  The sum of the values in the time range currently shown in the graph\.  | 
+
 
 For example, suppose you have a search expression **SEARCH\(' \{AWS/Lambda, FunctionName\} Errors ', 'Sum', 300\)**, which finds the `Errors` for each of your Lambda functions\. If you set the label to be `[max: ${MAX} Errors for Function Name ${LABEL}]`, the label for each metric is **\[max: *number* Errors for Function Name *Name*\]**\.
 


### PR DESCRIPTION
*Issue 77, if available:*

At https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/graph-dynamic-labels.html there are curly brackets instead of round brackets in the table for some of the new property dynamic labels:

MetricName
Namespace
Period
Region
Stat

For example in the table is shows: ${PROP('Stat'}}  instead of ${PROP('Stat')}


*Description of changes:*

Made the curly brackets round. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
