### PR TITLE
Key pair section was incorrect

### DIFF
--- a/doc_source/appinsights-tutorial-dotnet-sql.md
+++ b/doc_source/appinsights-tutorial-dotnet-sql.md
@@ -49,9 +49,11 @@ This CloudFormation template can also be found in the aws\-samples GitHub repo a
 
 1. On the **Specify stack details** page, enter a name for the stack, such as `ApplicationInsightsTest`\.
 
+1. Specify a key pair name in the **EC2 Key Pair** field to either create a new key pair or choose an existing key pair that you can use to log in to your EC2 instance\
+
 1. Review the default parameters under **Parameters** and modify the values to your preferences\. Enter a password for SQLServer\. Choose **Next**\.
 
-1. On the **Configure stack options** page, under **Tags**, create a new key pair or choose an existing key pair that you can use to log in to your EC2 instance\. Select **Next**\.
+1. On the **Configure stack options** page, under **Tags**, add any tags to help identify your stack . Select **Next**\.
 
 1. Review and confirm the settings on the **Review** page\. Select the box acknowledging that the template may create AWS Identity and Access Management \(IAM\) resources\.
 


### PR DESCRIPTION
The instructions to add the key pair details under Tags is incorrect. This needs to be done on the parameters section.

*Issue #, if available:*

*Description of changes:*
Instructions amended at point 4 and 6 to reflect the actual input locations for the key pair details on the cloudformation parameters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
