### PR TITLE
Changed AWSLambdaReadOnlyAccess to AWSLambda_ReadOnlyAccess

### DIFF
--- a/doc_source/CloudWatch_Synthetics_Canaries_Roles.md
+++ b/doc_source/CloudWatch_Synthetics_Canaries_Roles.md
@@ -1,6 +1,6 @@
 # Required roles and permissions for CloudWatch canaries<a name="CloudWatch_Synthetics_Canaries_Roles"></a>
 
-To view canary details and the results of canary runs, you must be signed in as an IAM user who has either the `CloudWatchSyntheticsFullAccess` or the `CloudWatchSyntheticsReadOnlyAccess` attached\. To read all Synthetics data in the console, you also need the `AmazonS3ReadOnlyAccess` and `CloudWatchReadOnlyAccess` policies\. To view the source code used by canaries, you also need the `AWSLambdaReadOnlyAccess` policy\.
+To view canary details and the results of canary runs, you must be signed in as an IAM user who has either the `CloudWatchSyntheticsFullAccess` or the `CloudWatchSyntheticsReadOnlyAccess` attached\. To read all Synthetics data in the console, you also need the `AmazonS3ReadOnlyAccess` and `CloudWatchReadOnlyAccess` policies\. To view the source code used by canaries, you also need the `AWSLambda_ReadOnlyAccess` policy\.
 
 To create canaries, you must be signed in as an IAM user who has the `CloudWatchSyntheticsFullAccess` policy or a similar set of permissions\. To create IAM roles for the canaries, you also need the following inline policy statement:
 


### PR DESCRIPTION
Description of changes:
Changed AWSLambdaReadOnlyAccess to AWSLambda_ReadOnlyAccess to reflect correct name for the policy

The policy name was changed on March 1st, please see here for more information:
https://docs.aws.amazon.com/lambda/latest/dg/access-control-identity-based.html


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
