### PR TITLE
synthetics.getPage() returns Page, not promise

### DIFF
--- a/doc_source/CloudWatch_Synthetics_Canaries_Library_Nodejs.md
+++ b/doc_source/CloudWatch_Synthetics_Canaries_Library_Nodejs.md
@@ -703,7 +703,7 @@ The following canary script code snippet demonstrates an example of navigating t
    let syntheticsLink = new SyntheticsLink(url);
    
    // Navigate to the url.
-   let page = await synthetics.getPage();
+   let page = synthetics.getPage();
    
    // Create a new instance of Synthetics Link
    let link = new SyntheticsLink(url)

--- a/doc_source/CloudWatch_Synthetics_Canaries_Samples.md
+++ b/doc_source/CloudWatch_Synthetics_Canaries_Samples.md
@@ -18,7 +18,7 @@ const pageLoadBlueprint = async function () {
 
     let url = "http://smile.amazon.com/";
 
-    let page = await synthetics.getPage();
+    let page = synthetics.getPage();
 
     // Set cookies.  I found that name, value, and either url or domain are required fields.
     const cookies = [{
@@ -72,7 +72,7 @@ const pageLoadBlueprint = async function () {
     // INSERT URL here
     const URL = "https://amazon.com";
 
-    let page = await synthetics.getPage();
+    let page = synthetics.getPage();
     await page.emulate(iPhone);
 
     //You can customize the wait condition here. For instance,

--- a/doc_source/CloudWatch_Synthetics_Canaries_WritingCanary_Nodejs.md
+++ b/doc_source/CloudWatch_Synthetics_Canaries_WritingCanary_Nodejs.md
@@ -114,7 +114,7 @@ The conversion steps are as follows:
 + Use the `Synthetics.getPage` function to get a Puppeteer `Page` object\.
 
   ```
-  const page = await synthetics.getPage();
+  const page = synthetics.getPage();
   ```
 
   The page object returned by the Synthetics\.getPage function has the **page\.on** `request`, `response` and `requestfailed` events instrumented for logging\. Synthetics also sets up HAR file generation for requests and responses on the page, and adds the canary ARN to the user\-agent headers of outgoing requests on the page\.
@@ -125,7 +125,7 @@ The script is now ready to be run as a Synthetics canary\. Here is the updated s
 var synthetics = require('Synthetics');  // Synthetics dependency
 
 const basicPuppeteerExample = async function () {
-    const page = await synthetics.getPage(); // Get instrumented page from Synthetics
+    const page = synthetics.getPage(); // Get instrumented page from Synthetics
     await page.goto('https://example.com');
     await page.screenshot({path: '/tmp/example.png'}); // Write screenshot to /tmp folder
 };
@@ -170,7 +170,7 @@ const pageLoadEnvironmentVariable = async function () {
     // INSERT URL here
     const URL = process.env.URL;
 
-    let page = await synthetics.getPage();
+    let page = synthetics.getPage();
     //You can customize the wait condition here. For instance,
     //using 'networkidle2' may be less restrictive.
     const response = await page.goto(URL, {waitUntil: 'domcontentloaded', timeout: 30000});
@@ -271,7 +271,7 @@ const getSecrets = async (secretName) => {
  
 const secretsExample = async function () {
     let URL = "<URL>";
-    let page = await synthetics.getPage();
+    let page = synthetics.getPage();
     
     log.info(`Navigating to URL: ${URL}`);
     const response = await page.goto(URL, {waitUntil: 'domcontentloaded', timeout: 30000});


### PR DESCRIPTION
Most of the samples use await with getPage() as if it's returning a promise, but it's not, it's returning a Page directly, so this is redundant.

getPage returns this._page, which is set by `this._page = await this._browser.newPage();`

Noticed this when using TypeScript to validate Canary code.

*Description of changes:*
remove await from all synthetics.getPage() calls

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.