### PR TITLE
Change to correct single quotation on Canaries sample

### DIFF
--- a/doc_source/CloudWatch_Synthetics_Canaries_Samples.md
+++ b/doc_source/CloudWatch_Synthetics_Canaries_Samples.md
@@ -164,7 +164,7 @@ const apiCanaryBlueprint = async function () {
     await synthetics.executeHttpStep('Verify GET products API with valid name', requestOptionsStep1, validatePositiveCase, stepConfig);
     
     let requestOptionsStep2 = {
-        'hostname': ‘myproductsEndpoint.com',
+        'hostname': 'myproductsEndpoint.com',
         'method': 'GET',
         'path': '/test/canary/InvalidName(',
         'port': 443,


### PR DESCRIPTION
The previous single quotation was the incorrect one causing a lot of the text to be commented out as seen here: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Synthetics_Canaries_Samples.html

*Issue #, if available:*
N/A

*Description of changes:*
I just changed the quotation to be the actual quote. As when looking in the example a lot of it is commented out because of how this quotation was implemented.

No clue why line 231 has any changes as there is no change here.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
