### PR TITLE
Corrected fluent-bit container name in filter

### DIFF
--- a/doc_source/Container-Insights-setup-logs-FluentBit.md
+++ b/doc_source/Container-Insights-setup-logs-FluentBit.md
@@ -174,7 +174,7 @@ To stop Fluent Bit application logs, remove the following section from the `Flue
 [INPUT]
         Name                tail
         Tag                 application.*
-        Path                /var/log/containers/fluent_bit*
+        Path                /var/log/containers/fluent-bit*
         Parser              docker
         DB                  /fluent-bit/state/flb_log.db
         Mem_Buf_Limit       5MB


### PR DESCRIPTION
In the example to filter out the fluent-bit logs the path has the wrong prefix for the container name. I've corrected this from fluent_bit to fluent-bit
