### PR TITLE
Simplify collectd installation on amz2

### DIFF
--- a/doc_source/CloudWatch-Agent-custom-metrics-collectd.md
+++ b/doc_source/CloudWatch-Agent-custom-metrics-collectd.md
@@ -7,8 +7,7 @@ You use the collectd software to send the metrics to the CloudWatch agent\. For 
 The collectd software is not installed automatically on every server\. On a server running Amazon Linux 2, follow these steps to install collectd
 
 ```
-sudo yum install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm
-sudo yum install -y collectd
+sudo amazon-linux-extras install collectd
 ```
 
 For information about installing collectd on other systems, see the [Download page for collectd\.](https://collectd.org/download.shtml) 


### PR DESCRIPTION
*Description of changes:*

Recently been installing `collectd` an fresh Amazon Linux 2 EC2 and I managed to do it in single step with `amazon-linux-extras`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
