### PR TITLE
Improved instructions to include namespace

### DIFF
--- a/doc_source/Container-Insights-prerequisites.md
+++ b/doc_source/Container-Insights-prerequisites.md
@@ -59,6 +59,6 @@ This method works only on Amazon EKS clusters\.
 
 1. If you haven't already, create the IAM role for your service account\. For more information, see [Creating an IAM role and policy for your service account](https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html)\. 
 
-   When you create the role, attach the **CloudWatchAgentServerPolicy** IAM policy to the role in addition to the policy that you create for the role\.
+   When you create the role, attach the **CloudWatchAgentServerPolicy** IAM policy to the role in addition to the policy that you create for the role\. Also, the associated Kubernetes ServiceAccount linked with this role should be created in `amazon-cloudwatch` namespace, where the CloudWatch and Fluent Bit daemonsets will be deployed in the upcoming steps.
 
 1. If you haven't already, associate the IAM role with a service account in your cluster\. For more information, see [Specifying an IAM role for your service account ](https://docs.aws.amazon.com/eks/latest/userguide/specify-service-account-role.html)


### PR DESCRIPTION
This document does not explicitly called out the namespace that is required to be linked with the IAM role having the policy **CloudWatchAgentServerPolicy** attached. Because of that, the users may create such role and the linked service account in a different namespace because the link to the document given here is a generic link that asks the users to create the service account in default namespace. Later in the document, the instructions deploys the CloudWatch and Fluent Bit agents in a namespace called `amazon-cloudwatch`. This mismatch does not grant required permissions to the deployed pods to communicate with the corresponding CloudWatch service on the AWS account. 

This little change will callout this namespace requirements explicitly to avoid any confusion or pain later, which would be otherwise almost unavoidable. 

Contact parthpg@amazon.com for more details if required.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
