### PR TITLE
Updated Windows commands

### DIFF
--- a/doc_source/create-cloudwatch-agent-configuration-file-wizard.md
+++ b/doc_source/create-cloudwatch-agent-configuration-file-wizard.md
@@ -82,11 +82,13 @@ Parameter Store supports parameters in Standard and Advanced tiers\. These param
    sudo /opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-config-wizard
    ```
 
-   On a server running Windows Server, enter the following:
+   On a server running Windows Server, run the following commands to launch the wizard:
 
    ```
    cd "C:\Program Files\Amazon\AmazonCloudWatchAgent"
-   amazon-cloudwatch-agent-config-wizard.exe
+   ```
+   ```
+   .\amazon-cloudwatch-agent-config-wizard.exe
    ```
 
 1. Answer the questions to customize the configuration file for your server\.


### PR DESCRIPTION
The single box of the command does not work when copied and pasted in Windows PowerShell because of the new-line character. Additionally, the `.exe` file had to be called for execution using the prefix as `.\`. Reach out to parthpg@amazon.com for more details if required.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
