### PR TITLE
fix: add an important note to uninstall Fluentd when installing Fluent-Bit

### DIFF
--- a/doc_source/Container-Insights-setup-logs-FluentBit.md
+++ b/doc_source/Container-Insights-setup-logs-FluentBit.md
@@ -39,6 +39,9 @@ The following list explains the differences between Fluentd and each Fluent Bit 
 
 ## Setting up Fluent Bit<a name="Container-Insights-FluentBit-setup"></a>
 
+**Important** 
+If you already have Fluentd configured as Container Insight and Fluentd DaemonSet is not running as expected (maybe the case when using the `containerd` runtime), you must uninstall it before installing Fluent-Bit to avoid Fluent-Bit from processing FLuentd's error log messages\.  Otherwise, you must uninstall Fluentd immediately after you have successfully installed Fluent-Bit\. The reason for uninstalling Fluentd (if it is working as expected) after installing Fluent-Bit is to ensure continuity in logging during this migration process.  Since both of these have the same purpose of sending Container Insight logs to CloudWatch, only one is needed\.
+
 To set up Fluent Bit to collect logs from your containers, you can follow the steps in [Quick Start setup for Container Insights on Amazon EKS and Kubernetes](Container-Insights-setup-EKS-quickstart.md) or you can follow the steps in this section\.
 
 With either method, the IAM role that is attached to the cluster nodes must have sufficient permissions\. For more information about the permissions required to run an Amazon EKS cluster, see [Amazon EKS IAM Policies, Roles, and Permissions](https://docs.aws.amazon.com/eks/latest/userguide/IAM_policies.html) in the *Amazon EKS User Guide*\.


### PR DESCRIPTION
*Description of changes:*

It is important to only have one Container Insight logging solution installed.  A worse case scenario is that Fluentd has the potential of generating a massive amount of container logs messages when its JSON parsers failed to parse non-JSON formatted log messages generated by the `containerd` runtime.  So when Fluent-Bit is installed and Fluentd is not yet uninstalled, Fluent-Bit will process all Fluentd's log messages.

*Issue #, if available:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
